### PR TITLE
Adjust styles imports

### DIFF
--- a/boilerplate/src/App.tsx
+++ b/boilerplate/src/App.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2020 Daimler TSS GmbH
 
-import { MuiThemeProvider, createMuiTheme, CssBaseline } from '@material-ui/core';
+import { CssBaseline } from '@material-ui/core';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { IDiContainer, IRouteConfig, ISwidget, Route, serviceIds, App, TranslationProvider } from '@daimler/ftk-core';
 import * as React from 'react';
 import TranslationsI18n from './globals/i18n/Translations';

--- a/boilerplate/src/components/HeaderBar.tsx
+++ b/boilerplate/src/components/HeaderBar.tsx
@@ -2,7 +2,8 @@
 // Copyright (c) 2020 Daimler TSS GmbH
 
 import * as React from 'react';
-import { AppBar, Typography, Toolbar, Grid, Link, makeStyles } from '@material-ui/core';
+import { AppBar, Typography, Toolbar, Grid, Link } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import LanguageSwitch from './LanguageSwitch';
 import { useRouter } from '@daimler/ftk-core';
 

--- a/boilerplate/src/components/LanguageSwitch.tsx
+++ b/boilerplate/src/components/LanguageSwitch.tsx
@@ -2,7 +2,8 @@
 // Copyright (c) 2020 Daimler TSS GmbH
 
 import * as React from 'react';
-import { Typography, Button, makeStyles } from '@material-ui/core';
+import { Typography, Button } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import LanguageIcon from '@material-ui/icons/Language';
 import CompareArrowsIcon from '@material-ui/icons/CompareArrows';
 import { useI18n } from '@daimler/ftk-core';

--- a/boilerplate/src/components/Logo.tsx
+++ b/boilerplate/src/components/Logo.tsx
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Daimler TSS GmbH
 
 import * as React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import imgLogo from '../assets/images/logo.png';
 
 const useStyles = makeStyles(({ spacing }) => ({

--- a/boilerplate/src/decorators/withLayout.tsx
+++ b/boilerplate/src/decorators/withLayout.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { useI18n } from '@daimler/ftk-core';
 import HeaderBar from '../components/HeaderBar';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
   pageContainer: {

--- a/boilerplate/src/routes/DemoContent.tsx
+++ b/boilerplate/src/routes/DemoContent.tsx
@@ -11,9 +11,6 @@
  */
 
 import {
-  createStyles,
-  withStyles,
-  WithStyles,
   Container,
   Typography,
   Box,
@@ -24,6 +21,7 @@ import {
   CardActionArea,
   Grid,
 } from '@material-ui/core';
+import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
 import { I18nService, inject, withInject, RouterService } from '@daimler/ftk-core';
 import * as React from 'react';
 import Logo from '../assets/images/logo.png';

--- a/boilerplate/src/routes/Home.tsx
+++ b/boilerplate/src/routes/Home.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2020 Daimler TSS GmbH
 
-import { Theme, Container, Typography, Box, Button, makeStyles } from '@material-ui/core';
+import { Container, Typography, Box, Button } from '@material-ui/core';
+import { Theme, makeStyles } from '@material-ui/core/styles';
 import { useI18n, useConfig, useRouter } from '@daimler/ftk-core';
 import * as React from 'react';
 import Logo from '../components/Logo';


### PR DESCRIPTION
I'm not sure, if this is really necessary, as the core exports everything from styles by default,
but I ran into an issue, where makeStyles could occasionally not be found in the exposed material-ui bundle.
Fixes #21 

This should fix this issue.
___
Acting on behalf of Daimler TSS GmbH.