### PR TITLE
Quickfix for swidget dev-mode, as react-dom is not exposed by hostapp

### DIFF
--- a/boilerplate/.build/webpack/exposed.modules.js
+++ b/boilerplate/.build/webpack/exposed.modules.js
@@ -19,6 +19,15 @@ const defaultExposedModules = {
 };
 
 /**
+ * Quickfix for DEV-Mode
+ * As react-dom is resolved by the hot-loader,
+ * it will not be exposed by the hostapp and should therefore be excluded from the exposed-list.
+ */
+if (process.env.build === 'dev') {
+  delete(defaultExposedModules['react-dom']);
+}
+
+/**
  *
  * Adds our list of exposed modules to a webpack { rules: [] } section to mark the to be loaded via
  * expose-loader.


### PR DESCRIPTION
This is probably not the cleanest solution, but makes dev-mode for swidget at least possible.
Until we have a better solution, we should add this, as it does not effect the prod build and the normal dev-mode.
Fixes #22 
___
Acting on behalf of Daimler TSS GmbH.