### PR TITLE
#34 App component from @daimler/ftk-core swallows any exception --> can't unittest components using i18n

### DIFF
--- a/core/src/core/registerDefaultDependencies.tsx
+++ b/core/src/core/registerDefaultDependencies.tsx
@@ -10,6 +10,7 @@ import { InterconnectionService } from '../interconnection/InterconnectionServic
 import IRouteConfig from '../router/component/interface/IRouteConfig';
 import DefaultRouterStrategy from '../router/lib/urlFormatStrategy/DefaultRouterStrategy';
 import serviceIds from './serviceIds';
+import {DefaultErrorHandlerStrategy} from '../errorHandler/lib/DefaultErrorHandlerStrategy';
 
 function registerDefaultDependencies(container: IDiContainer, name: string) {
   container.bind(serviceIds.name).toConstantValue(name);
@@ -50,6 +51,9 @@ function registerDefaultDependencies(container: IDiContainer, name: string) {
   const url: URL = new URL(window.location.href) as any;
   container.bind(serviceIds.currentSwidget.url).toConstantValue(url);
   container.bind(serviceIds.currentSwidget.assetResolver).toConstantValue(getDefaultAssetResolver(url));
+
+  /** error-handler */
+  container.bind(serviceIds.errorHandlerStrategy).toConstantValue(new DefaultErrorHandlerStrategy());
 }
 
 registerDefaultDependencies.displayName = 'registerDefaultDependencies';

--- a/core/src/core/serviceIds.ts
+++ b/core/src/core/serviceIds.ts
@@ -12,6 +12,7 @@ const serviceIds = {
   translations: 'ftk.core.translations',
   routerUrlFormatStrategy: 'ftk.core.router.urlFormatStrategy',
   routes: 'ftk.core.routes',
+  errorHandlerStrategy: 'ftk.core.errorHandler.strategy',
 };
 
 export default serviceIds;

--- a/core/src/errorHandler/lib/DefaultErrorHandlerStrategy.ts
+++ b/core/src/errorHandler/lib/DefaultErrorHandlerStrategy.ts
@@ -3,19 +3,14 @@
 
 import IErrorHandlerStrategy from './interface/IErrorHandlerStrategy';
 
-export class ErrorHandler {
-  protected strategy: IErrorHandlerStrategy;
-
-  constructor(strategy: IErrorHandlerStrategy) {
-    this.strategy = strategy
-  }
-
+export class DefaultErrorHandlerStrategy implements IErrorHandlerStrategy {
   /**
    * @param message
    * @param stacktrace
    * @return void
    */
   public handleError(message: string, stacktrace: string): void {
-    this.strategy.handleError(message, stacktrace)
+    // tslint:disable-next-line
+    console.log('[Error Handler] ' + message, stacktrace);
   }
 }

--- a/core/src/errorHandler/lib/interface/IErrorHandlerStrategy.ts
+++ b/core/src/errorHandler/lib/interface/IErrorHandlerStrategy.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2020 Daimler TSS GmbH
+
+interface IErrorHandlerStrategy {
+  handleError(message: string, stacktrace: string): void
+}
+
+export default IErrorHandlerStrategy;

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -13,6 +13,7 @@ export { ConfigProvider } from './config/component/Provider';
 
 // ErrorHandler
 export { ErrorHandler } from './errorHandler/lib/ErrorHandler';
+export { default as IErrorHandlerStrategy } from './errorHandler/lib/interface/IErrorHandlerStrategy';
 
 import { interfaces } from 'inversify';
 export type IDiContainer = interfaces.Container;


### PR DESCRIPTION
- currently its not possible to invoke a custom error-handler strategy
- previously it was possible, I think we accidentally dropped it when we prepared mo360-ftk for github
- since we cannot break the API I kept the `ErrorHandler`-service and added a strategy-pattern which allows us to separate error-handling-logic vom the actual `ErrorHandler`-service
- I moved our current error-handling-logic into `DefaultErrorHandlerStrategy`
- simply invoke a custom-handler by binding it

```typescript
container.bind<IErrorHandlerStrategy>(serviceIds.errorHandlerStrategy).toConstantValue({
    handleError: (message: string, stacktrace: string): void => {
        // do something else
    },
})
```


