### PR TITLE
Fix error when router object should be used via injection

### DIFF
--- a/packages/core/src/core/App.tsx
+++ b/packages/core/src/core/App.tsx
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-
 import { Container } from 'inversify';
 import { once } from 'lodash';
 import * as React from 'react';
@@ -67,6 +64,13 @@ export class App extends React.Component<IAppProps & PropsWithChildren, {}> {
         return custom;
       }
     }
+
+    // Bind RouterServiceType to the DI container
+    appContainer.bind(serviceIds.routerService).toDynamicValue(() => {
+      const routerService = containerFromContext?.get(serviceIds.routerService);
+      return routerService;
+    });
+
     return appContainer;
   });
 

--- a/packages/core/src/di/hoc/inject.tsx
+++ b/packages/core/src/di/hoc/inject.tsx
@@ -1,9 +1,7 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-
 import { interfaces } from 'inversify';
 import 'reflect-metadata';
 import { IDiContainer } from '../..';
+import serviceIds from '../../core/serviceIds';
 
 export default function inject(serviceId?: string | symbol | interfaces.Newable<{}>) {
   return (target: any, propertyKey: string) => {

--- a/packages/core/src/router/component/RouterProvider.tsx
+++ b/packages/core/src/router/component/RouterProvider.tsx
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2022 Mercedes-Benz Tech Innovation GmbH
-
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import BindToDi from '../../di/component/BindToDi';
@@ -78,7 +75,7 @@ const RouterProvider: React.FunctionComponent<IRouterProviderProps> = (props) =>
   return (
     <BindToDi
       services={(container) => {
-        container.bind<RouterServiceType>(serviceIds.routerService).toConstantValue({
+        container.bind<RouterServiceType>(serviceIds.routerService).toDynamicValue(() => ({
           getRoute() {
             return {
               parameter: activeRouteRef.current.parameter,
@@ -120,7 +117,7 @@ const RouterProvider: React.FunctionComponent<IRouterProviderProps> = (props) =>
               ),
             );
           },
-        });
+        }));
       }}
     >
       <Route key={activeRoute.url} url={activeRoute.url} />


### PR DESCRIPTION
Related to #57

Bind `RouterServiceType` to the DI container in the `init` function in `App.tsx`.

* Bind `RouterServiceType` to the DI container in the `init` function in `App.tsx` using `serviceIds.routerService`.
* Ensure `RouterServiceType` is correctly bound to the DI container in `RouterProvider.tsx` using `serviceIds.routerService`.
* Check for the binding of `RouterServiceType` in the DI container in `inject.tsx` using `serviceIds.routerService`.

